### PR TITLE
Laravel 11 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto
+
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
+
+public/*.css binary
+public/*.js binary
+
+/.github export-ignore
+/assets export-ignore
+/tests export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+CHANGELOG.md export-ignore
+phpstan.neon.dist export-ignore
+phpunit.xml.dist export-ignore
+rector.php export-ignore
+RELEASE.md export-ignore
+UPGRADE.md export-ignore

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "require": {
         "php": "^8.1",
         "laravel/framework": "^10.21|^11.0",
-        "laravel/pulse": "^1.0@beta",
-        "thecodingmachine/phpstan-safe-rule": "^1.2"
+        "laravel/pulse": "^1.0@beta"
     },
     "require-dev": {
         "larastan/larastan": "^2.9",
@@ -29,7 +28,8 @@
         "phpstan/extension-installer": "^1.3.1",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "rector/rector": "^1.0",
-        "spaze/phpstan-disallowed-calls": "^3.1"
+        "spaze/phpstan-disallowed-calls": "^3.1",
+        "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/ScheduleServiceProvider.php
+++ b/src/ScheduleServiceProvider.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace HosmelQ\Laravel\Pulse\Schedule;
 
 use HosmelQ\Laravel\Pulse\Schedule\Livewire\Schedule;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Livewire\LivewireManager;
 
-class ScheduleServiceProvider extends ServiceProvider
+class ScheduleServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     public function boot(): void
     {
@@ -17,5 +18,13 @@ class ScheduleServiceProvider extends ServiceProvider
         $this->callAfterResolving('livewire', function (LivewireManager $livewire): void {
             $livewire->component('pulse.schedule', Schedule::class);
         });
+    }
+
+    /**
+     * @return array<class-string>
+     */
+    public function provides()
+    {
+        return [\Laravel\Pulse\Pulse::class];
     }
 }


### PR DESCRIPTION
1. Laravel 11 didn't have `\App\Console\Kernel::class` but if user create them `\Illuminate\Contracts\Console\Kernel::class` resolve actual implementation.
2. `$kernel->bootstrap();` will collect events not only from the kernel, but also from the file `routes/console.php`
3. Append `DeferrableProvider` to `ScheduleServiceProvider` for optimize resources. [Read more](https://laravel.com/docs/10.x/providers#deferred-providers)
4. Append `.gitattributes` to exclude unnecessary files from the package delivery